### PR TITLE
feat(ingress): add support for generic Ingress controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ If you're using TraefikV2, run the following:
 kubectl -n sample-project apply -f ./k8s/traefik
 ```
 
+Or, if you use an Ingress Controller that supports [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/), run the following:
+
+```bash
+kubectl -n sample-project apply -f ./k8s/ingress
+```
+
 To use a generic LoadBalance service, run the following:
 
 ```bash

--- a/k8s/ingress/frontend.yaml
+++ b/k8s/ingress/frontend.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sample-project-frontend
+  labels:
+    app: sample-project
+    component: frontend
+spec:
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 80
+  selector:
+    app: sample-project
+    component: frontend
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: sample-project-ingress
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: sample-project-frontend
+            port:
+              number: 80


### PR DESCRIPTION
## Description

This adds an alternative to using Traefik specific ingress routing or just a raw `LoadBalancer`, by creating an option to use a generic Kubernetes Ingress resource.  This should work with most ingress controllers like Kong, Nginx, HA Proxy Ingress etc.  See [Ingress Controllers](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/) for a list of supported controllers.