### PR TITLE
Add the ability to build using kustomize

### DIFF
--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,0 +1,10 @@
+resources:
+- namespace.yaml
+- ingress/frontend.yaml
+- core.yaml
+- database.yaml
+- frontend.yaml
+- leaf.yaml
+- sockets.yaml
+
+namespace: sample-project

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sample-project


### PR DESCRIPTION
## Description

This adds the ability to install the sample project using kustomize, which will create the NS, ingress and other resources in an ordered manor. 

This should change the setup to:

```
kubectl create -k k8s
```

fixes #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Technical improvement or removal of technical debt. 
- [ ] Minor change: comments, documentation, trivial fixes

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Unit Tests

Optional:

- [ ] Functional Tests
- [ ] Integration Tests

