### PR TITLE
Update external.yaml - switch external API test resource

### DIFF
--- a/k8s/external.yaml
+++ b/k8s/external.yaml
@@ -7,7 +7,7 @@ metadata:
     component: external
 spec:
   type: ExternalName
-  externalName: dummy.restapiexample.com
+  externalName: jsonplaceholder.typicode.com
   ports:
   - port: 80
     name: http


### PR DESCRIPTION
## Description
switching from  **dummy.restapiexample.com** to **jsonplaceholder.typicode.com**

They support this query without SSL "[http://jsonplaceholder.typicode.com/todos/1](http://jsonplaceholder.typicode.com/todos/1)" 

so we should be able to consume the **sample-project-external** service and issue this from local terminal:

`curl -s http://sample-project-example/todos/1 | jq`

with this successful result

`{
  "userId": 1,
  "id": 1,
  "title": "delectus aut autem",
  "completed": false
}`

fixes #issue
broken responses from [dummy.restapiexample.com](dummy.restapiexample.com) - no longer works as expected
